### PR TITLE
fix: restore ask-hansol API in production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "export",
   images: { unoptimized: true },
   /** Claude Design `TweaksPanel` — gradually add types in `src/components/TweaksPanel.tsx` */
   typescript: { ignoreBuildErrors: true },

--- a/scripts/refresh-site-data-with-claude.ts
+++ b/scripts/refresh-site-data-with-claude.ts
@@ -67,6 +67,34 @@ function parseJsonWithFallback(text: string): unknown {
   return extractJson(normalized);
 }
 
+function tryParseJsonString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) return value;
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeNestedJsonLikeStrings(input: unknown): unknown {
+  if (Array.isArray(input)) {
+    return input.map((item) => normalizeNestedJsonLikeStrings(item));
+  }
+  if (typeof input === "string") {
+    const parsed = tryParseJsonString(input);
+    if (parsed === input) return input;
+    return normalizeNestedJsonLikeStrings(parsed);
+  }
+  if (input && typeof input === "object") {
+    return Object.fromEntries(
+      Object.entries(input).map(([key, value]) => [key, normalizeNestedJsonLikeStrings(value)]),
+    );
+  }
+  return input;
+}
+
 async function writeFailureDump(args: {
   stage: string;
   initialResponse: string;
@@ -284,7 +312,8 @@ ${contextText}
       parsed = parseJsonWithFallback(text);
     }
 
-    const validated = siteDataSchema.safeParse(parsed);
+    const normalizedParsed = normalizeNestedJsonLikeStrings(parsed);
+    const validated = siteDataSchema.safeParse(normalizedParsed);
     if (validated.success) {
       logStep(`Writing refreshed site-data: ${SITE_DATA_PATH}`);
       await mkdir(path.dirname(SITE_DATA_PATH), { recursive: true });


### PR DESCRIPTION
## Summary
- remove `output: \"export\"` from `next.config.ts` so API routes are deployed as Vercel Functions
- restore `/api/ask-hansol` availability in production where static export previously caused 404 responses

## Test plan
- [x] Confirm `next.config.ts` no longer sets `output: \"export\"`
- [ ] Deploy to production with `vercel --prod`
- [ ] Verify `POST /api/ask-hansol` returns an answer payload instead of fallback after 404

Made with [Cursor](https://cursor.com)